### PR TITLE
Fix git fetch

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_meta-elastic-beats = "^${LAYERDIR}/"
 BBFILE_PRIORITY_meta-elastic-beats = "6"
 
 LAYERDEPENDS_meta-elastic-beats = "core"
-LAYERSERIES_COMPAT_meta-elastic-beats = "dunfell gatesgarth hardknott honister"
+LAYERSERIES_COMPAT_meta-elastic-beats = "dunfell gatesgarth hardknott honister kirkstone"

--- a/recipes-devops/elastic-beats/elastic-beats.inc
+++ b/recipes-devops/elastic-beats/elastic-beats.inc
@@ -22,7 +22,7 @@ SRCREV = "${AUTOREV}"
 FILESEXTRAPATHS:append = "${THISDIR}/elastic-beats:"
 
 SRC_URI = " \
-        git://${GO_IMPORT}.git \
+        git://${GO_IMPORT}.git;protocol=https \
         file://${GO_PACKAGE}.yml \
         "
 

--- a/recipes-devops/elastic-beats/elastic-beats.inc
+++ b/recipes-devops/elastic-beats/elastic-beats.inc
@@ -22,7 +22,7 @@ SRCREV = "${AUTOREV}"
 FILESEXTRAPATHS:append = "${THISDIR}/elastic-beats:"
 
 SRC_URI = " \
-        git://${GO_IMPORT}.git;protocol=https \
+        git://${GO_IMPORT}.git;protocol=https;branch=7.13 \
         file://${GO_PACKAGE}.yml \
         "
 

--- a/recipes-devops/elastic-beats/mage-native_git.bb
+++ b/recipes-devops/elastic-beats/mage-native_git.bb
@@ -12,7 +12,7 @@ SRCREV = "${AUTOREV}"
 
 GO_INSTALL = "${GO_IMPORT}"
 
-SRC_URI = "git://${GO_IMPORT}.git"
+SRC_URI = "git://${GO_IMPORT}.git;protocol=https"
 
 DEPENDS += "\
 "

--- a/recipes-devops/elastic-beats/mage-native_git.bb
+++ b/recipes-devops/elastic-beats/mage-native_git.bb
@@ -12,7 +12,7 @@ SRCREV = "${AUTOREV}"
 
 GO_INSTALL = "${GO_IMPORT}"
 
-SRC_URI = "git://${GO_IMPORT}.git;protocol=https"
+SRC_URI = "git://${GO_IMPORT}.git;protocol=https;branch=master"
 
 DEPENDS += "\
 "


### PR DESCRIPTION
Github seems to have closed down the original git protocol that results in this error:
```
fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see https://github.blog/2021-09-01-improving-git-protocol-security-github/ for more information.
```
This PR fixes the error by switching to the https git protocol method in SRC_URI.