### PR TITLE
put the beat binary in a "bin" subfolder

### DIFF
--- a/recipes-devops/elastic-beats/elastic-beats.inc
+++ b/recipes-devops/elastic-beats/elastic-beats.inc
@@ -40,11 +40,11 @@ do_compile() {
 do_install() {
     create_exec_script
 
-	install -d ${D}${bindir}/
-	install -m 0755 ${WORKDIR}/${GO_PACKAGE} ${D}${bindir}
+    install -d ${D}${bindir}/
+    install -m 0755 ${WORKDIR}/${GO_PACKAGE} ${D}${bindir}
 
-    install -d ${D}${datadir}/${GO_PACKAGE}
-	install -m 0755 ${BEAT_FOLDER}/${GO_PACKAGE} ${D}${datadir}/${GO_PACKAGE}
+    install -d ${D}${datadir}/${GO_PACKAGE}/bin
+    install -m 0755 ${BEAT_FOLDER}/${GO_PACKAGE} ${D}${datadir}/${GO_PACKAGE}/bin/
 
     install -d ${D}${sysconfdir}/${GO_PACKAGE}
     install -m 0755 ${WORKDIR}/${GO_PACKAGE}.yml ${D}${sysconfdir}/${GO_PACKAGE}/${GO_PACKAGE}.yml
@@ -64,7 +64,7 @@ create_exec_script() {
 # Script to run ${GO_PACKAGE} in foreground with the same path settings that
 # the init script / systemd unit file would do.
 
-exec ${datadir}/${GO_PACKAGE}/${GO_PACKAGE} \\
+exec ${datadir}/${GO_PACKAGE}/bin/${GO_PACKAGE} \\
   --path.home ${datadir}/${GO_PACKAGE} \\
   --path.config ${sysconfdir}/${GO_PACKAGE} \\
   --path.data ${localstatedir}/lib/${GO_PACKAGE} \\


### PR DESCRIPTION
This is to match what is actually done by Elastic in their packaged distribution of beats
see : https://github.com/elastic/beats/blob/master/dev-tools/packaging/templates/linux/elastic-agent.sh.tmpl