### PR TITLE
Bugfix: build behind http proxy [dunfell]

### DIFF
--- a/recipes-devops/elastic-beats/elastic-beats.inc
+++ b/recipes-devops/elastic-beats/elastic-beats.inc
@@ -27,6 +27,8 @@ do_compile() {
     set -x
     cd ${GO_PACKAGE}
     #GOOS=linux GOARCH=arm go build
+    export http_proxy="${http_proxy}"
+    export https_proxy="${https_proxy}"
     go build
     go clean -modcache
     rm -rf src/${GO_IMPORT}/pkg/mod


### PR DESCRIPTION
This patch fixes the abiltiy to build when behind a corporate firewall and HTTP traffic needs to go via an http(s) proxy 