### PR TITLE
Bugfix: build behind http proxy [master]

### DIFF
--- a/recipes-devops/elastic-beats/elastic-beats.inc
+++ b/recipes-devops/elastic-beats/elastic-beats.inc
@@ -30,6 +30,8 @@ RDEPENDS:${PN}-dev += "bash"
 
 do_compile() {
     cd ${GO_PACKAGE}
+    export http_proxy="${http_proxy}"
+    export https_proxy="${https_proxy}"
     go build
     # This is needed to remove read-only files
     go clean -modcache


### PR DESCRIPTION
This patch fixes the ability to build when behind a corporate firewall and HTTP traffic needs to go via an http(s) proxy 